### PR TITLE
Rollback to savepoints on exceptions

### DIFF
--- a/gumbo_client/client.py
+++ b/gumbo_client/client.py
@@ -246,7 +246,6 @@ class Client:
             print("setting username to", username)
             cursor.execute("SET my.username=%s", [username])
 
-
     def get(self, table_name):
         cursor = self.connection.cursor()
         _set_savepoint(cursor)
@@ -258,7 +257,7 @@ class Client:
             raise
         finally:
             cursor.close()
-        
+
         df = pd.read_sql(
             f"select * from {table_name} order by {pk_column}", self.connection
         )


### PR DESCRIPTION
**Sets a savepoint when:**
- a read or write succeeds 
- the client is initialized (in case an exception occurs on the first attempt to read/write) 

I tested this out with the following little script:
```
import pandas as pd
from gumbo_client.client import Client

client = Client(config_dir="~/.config/gumbo-staging", username="swessel") # savepoint set
table_name = "model_primary_disease_term"

new_terms = pd.DataFrame({"term": ["new_test_term"]})
client.insert_only(table_name, new_terms) # savepoint set

# try to get a table that doesn't exist to see how the exception is handled
try:
    existing_terms = client.get("non_existant_table") # should rollback to previous savepoint
except:
    terms = client.get(table_name) # savepoint set
    print("Updated terms:" , terms) # results should include "new_test_term"

client.rollback()
client.close()
```

I also explicitly checked that it was okay for us to use the same savepoint name every time (and it is, it just rolls back to the most recent usage of that savepoint name).